### PR TITLE
RBAC: replace `cluster-admin` with "just" reading secrets

### DIFF
--- a/deploy/chart/templates/rbac.yaml
+++ b/deploy/chart/templates/rbac.yaml
@@ -4,6 +4,15 @@ metadata:
   name: {{ include "secret-transform.name" . }}
   namespace: {{ .Release.Namespace }}
 ---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: "{{ include "secret-transform.name" . }}"
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["list", "watch", "update"]
+---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -11,8 +20,9 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: cluster-admin
+  name: "{{ include "secret-transform.name" . }}"
 subjects:
   - kind: ServiceAccount
     name: {{ include "secret-transform.name" . }}
     namespace: {{ .Release.Namespace }}
+---


### PR DESCRIPTION
The Helm chart currently relies on the god-mode `cluster-admin` cluster role, which looks bad, really bad.

