### PR TITLE
feat: Scoping RBAC or disabling

### DIFF
--- a/deploy/chart/templates/rbac-cluster.yaml
+++ b/deploy/chart/templates/rbac-cluster.yaml
@@ -1,8 +1,4 @@
-kind: ServiceAccount
-apiVersion: v1
-metadata:
-  name: {{ include "secret-transform.name" . }}
-  namespace: {{ .Release.Namespace }}
+{{- if and .Values.rbac.enabled (eq (len .Values.rbac.namespaces) 0) -}}
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -25,4 +21,4 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "secret-transform.name" . }}
     namespace: {{ .Release.Namespace }}
----
+{{- end }}

--- a/deploy/chart/templates/rbac-namespace.yaml
+++ b/deploy/chart/templates/rbac-namespace.yaml
@@ -1,0 +1,28 @@
+{{- if and .Values.rbac.enabled (gt (len .Values.rbac.namespaces) 0) -}}
+{{- range $.Values.rbac.namespaces }}
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: "{{ include "secret-transform.name" $ }}"
+  namespace: {{ . | quote }}
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["list", "watch", "update"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: "{{ include "secret-transform.name" $ }}"
+  namespace: {{ . | quote }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: "{{ include "secret-transform.name" $ }}"
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "secret-transform.name" $ }}
+    namespace: {{ $.Release.Namespace }}
+{{- end }}
+{{- end }}

--- a/deploy/chart/templates/serviceaccount.yaml
+++ b/deploy/chart/templates/serviceaccount.yaml
@@ -1,0 +1,6 @@
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: {{ include "secret-transform.name" . }}
+  namespace: {{ .Release.Namespace }}

--- a/deploy/chart/tests/namespaced-values.yaml
+++ b/deploy/chart/tests/namespaced-values.yaml
@@ -1,0 +1,3 @@
+rbac:
+  enabled: true
+  namespaces: ["secret-transform", default]

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -19,3 +19,7 @@ resources:
 selectorLabels:
   app.kubernetes.io/name: '{{ include "secret-transform.name" $ }}'
   app.kubernetes.io/instance: "{{ $.Release.Name }}"
+
+rbac:
+  enabled: true
+  namespaces: []


### PR DESCRIPTION
**THIS IS A WIP - NO MERGE**

Allow the helm chart installation to disable RBAC.
Allow the installation to scope to namespaces specified, otherwise it uses a cluster scope.


