### PR TITLE
feat: add abilitiy to rename keystores

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,9 @@ annotations:
 kind: Secret
 metadata:
   annotations:
-    cert-manager.io/secret-copy-ca.crt: caFile      # ✨ "ca.crt" to be renamed to "caFile"
-    cert-manager.io/secret-copy-tls.crt: certFile   # ✨ "tls.crt" to be renamed to "certFile"
-    cert-manager.io/secret-copy-tls.key: keyFile    # ✨ "tls.key" to be renamed to "keyFile"
+    cert-manager.io/secret-copy-ca.crt: caFile    # ✨ "ca.crt" to be renamed to "caFile"
+    cert-manager.io/secret-copy-tls.crt: certFile # ✨ "tls.crt" to be renamed to "certFile"
+    cert-manager.io/secret-copy-tls.key: keyFile  # ✨ "tls.key" to be renamed to "keyFile"
 stringData:
   tls.crt: <the PEM-encoded contents of the certificate>
   tls.key: <the PEM-encoded contents of the private key>

--- a/README.md
+++ b/README.md
@@ -78,9 +78,9 @@ annotations:
 kind: Secret
 metadata:
   annotations:
-    cert-manager.io/secret-copy-ca.crt: caFile    # ✨ "ca.crt" to be renamed to "caFile"
-    cert-manager.io/secret-copy-tls.crt: certFile # ✨ "tls.crt" to be renamed to "certFile"
-    cert-manager.io/secret-copy-tls.key: keyFile  # ✨ "tls.key" to be renamed to "keyFile"
+    cert-manager.io/secret-copy-ca.crt: caFile              # ✨ "ca.crt" to be renamed to "caFile"
+    cert-manager.io/secret-copy-tls.crt: certFile           # ✨ "tls.crt" to be renamed to "certFile"
+    cert-manager.io/secret-copy-tls.key: keyFile            # ✨ "tls.key" to be renamed to "keyFile"
 stringData:
   tls.crt: <the PEM-encoded contents of the certificate>
   tls.key: <the PEM-encoded contents of the private key>
@@ -103,6 +103,79 @@ After adding the annotations, you will see the new keys appear in the Secret:
 +   certFile: <copied from tls.crt>
 +   keyFile: <copied from tls.key>
 +   caFile: <copied from ca.crt>
+```
+
+## Renaming of optional keystore keys
+
+cert-manager is able to optionally provide keystores in JKS or/and PKCS#12 format.
+Similar to renaming the default Keys you can use it to rename your keystore keys.
+
+**JKS:**
+
+```yaml
+kind: Secret
+metadata:
+  annotations:
+    cert-manager.io/secret-copy-keystore.jks: keystore      # ✨ "keystore.jks" to be renamed to "keystore"
+    cert-manager.io/secret-copy-truststore.jks: truststore  # ✨ "truststore.jks" to be renamed to "truststore"
+stringData:
+  tls.crt: <the PEM-encoded contents of the certificate>
+  tls.key: <the PEM-encoded contents of the private key>
+  ca.crt: <the PEM-encoded contents of the CA certificate>
+  keystore.jks: <keystore that holds the certificate and the private key>
+  truststore.jks: <truststore that holds the CA certificate>
+```
+
+After adding the annotations, you will see the new keys appear in the Secret:
+
+```diff
+ kind: Secret
+ metadata:
+   annotations:
+    cert-manager.io/secret-copy-keystore.jks: keystore
+    cert-manager.io/secret-copy-truststore.jks: truststore
+ data:
+    tls.crt: <the PEM-encoded contents of the certificate>
+    tls.key: <the PEM-encoded contents of the private key>
+    ca.crt: <the PEM-encoded contents of the CA certificate>
+    keystore.jks: <keystore that holds the certificate and the private key>
+    truststore.jks: <truststore that holds the CA certificate>
++   keystore: <copied from keystore.jks>
++   truststore: <copied from truststore.jks>
+```
+
+**PKCS#12:**
+
+```yaml
+kind: Secret
+metadata:
+  annotations:
+    cert-manager.io/secret-copy-keystore.p12: keystore      # ✨ "keystore.p12" to be renamed to "keystore"
+    cert-manager.io/secret-copy-truststore.p12: truststore  # ✨ "truststore.p12" to be renamed to "truststore"
+stringData:
+  tls.crt: <the PEM-encoded contents of the certificate>
+  tls.key: <the PEM-encoded contents of the private key>
+  ca.crt: <the PEM-encoded contents of the CA certificate>
+  keystore.p12: <keystore that holds the certificate and the private key>
+  truststore.p12: <truststore that holds the CA certificate>
+```
+
+After adding the annotations, you will see the new keys appear in the Secret:
+
+```diff
+ kind: Secret
+ metadata:
+   annotations:
+    cert-manager.io/secret-copy-keystore.p12: keystore
+    cert-manager.io/secret-copy-truststore.p12: truststore
+ data:
+    tls.crt: <the PEM-encoded contents of the certificate>
+    tls.key: <the PEM-encoded contents of the private key>
+    ca.crt: <the PEM-encoded contents of the CA certificate>
+    keystore.p12: <keystore that holds the certificate and the private key>
+    truststore.p12: <truststore that holds the CA certificate>
++   keystore: <copied from keystore.p12>
++   truststore: <copied from truststore.p12>
 ```
 
 ### Use-case: Redis Enterprise for Kubernetes

--- a/README.md
+++ b/README.md
@@ -78,9 +78,9 @@ annotations:
 kind: Secret
 metadata:
   annotations:
-    cert-manager.io/secret-copy-ca.crt: caFile              # ✨ "ca.crt" to be renamed to "caFile"
-    cert-manager.io/secret-copy-tls.crt: certFile           # ✨ "tls.crt" to be renamed to "certFile"
-    cert-manager.io/secret-copy-tls.key: keyFile            # ✨ "tls.key" to be renamed to "keyFile"
+    cert-manager.io/secret-copy-ca.crt: caFile      # ✨ "ca.crt" to be renamed to "caFile"
+    cert-manager.io/secret-copy-tls.crt: certFile   # ✨ "tls.crt" to be renamed to "certFile"
+    cert-manager.io/secret-copy-tls.key: keyFile    # ✨ "tls.key" to be renamed to "keyFile"
 stringData:
   tls.crt: <the PEM-encoded contents of the certificate>
   tls.key: <the PEM-encoded contents of the private key>

--- a/main.go
+++ b/main.go
@@ -54,13 +54,21 @@ const (
 	//  cert-manager.io/secret-copy-ca.crt: "ca"
 	//  cert-manager.io/secret-copy-tls.crt: "cert"
 	//  cert-manager.io/secret-copy-tls.key: "key"
+	//  cert-manager.io/secret-copy-keystore.jks: "keystore"
+	//  cert-manager.io/secret-copy-truststore.jks: "truststore"
+	//  cert-manager.io/secret-copy-keystore.p12: "keystore"
+	//  cert-manager.io/secret-copy-truststore.p12: "truststore"
 	//
 	// In the first example, the contents of the `ca.crt` key will be copied to
 	// a new key `ca`, even when the Secret's `ca.crt` is updated. Each of the
 	// annotation values are configurable.
-	secretSyncCACRTAnnotKey  = "cert-manager.io/secret-copy-ca.crt"
-	secretSyncTLSCrtAnnotKey = "cert-manager.io/secret-copy-tls.crt"
-	secretSyncTLSKeyAnnotKey = "cert-manager.io/secret-copy-tls.key"
+	secretSyncCACRTAnnotKey         = "cert-manager.io/secret-copy-ca.crt"
+	secretSyncTLSCrtAnnotKey        = "cert-manager.io/secret-copy-tls.crt"
+	secretSyncTLSKeyAnnotKey        = "cert-manager.io/secret-copy-tls.key"
+	secretSyncKeystoreJKSAnnotKey   = "cert-manager.io/secret-copy-keystore.jks"
+	secretSyncTruststoreJKSAnnotKey = "cert-manager.io/secret-copy-truststore.jks"
+	secretSyncKeystoreP12AnnotKey   = "cert-manager.io/secret-copy-keystore.p12"
+	secretSyncTruststoreP12AnnotKey = "cert-manager.io/secret-copy-truststore.p12"
 )
 
 func init() {
@@ -126,6 +134,46 @@ func main() {
 				}
 			}
 
+			copyKeystoreJKSKey := secret.GetAnnotations()[secretSyncKeystoreJKSAnnotKey]
+			if copyKeystoreJKSKey != "" {
+				copyKey(secret, "keystore.jks", copyKeystoreJKSKey)
+				if err != nil {
+					log.WithValues(err, "while copying")
+					rec.Eventf(&secret, corev1.EventTypeWarning, "FailedCopying", err.Error())
+					return reconcile.Result{}, nil
+				}
+			}
+
+			copyTruststoreJKSKey := secret.GetAnnotations()[secretSyncTruststoreJKSAnnotKey]
+			if copyTruststoreJKSKey != "" {
+				copyKey(secret, "truststore.jks", copyTruststoreJKSKey)
+				if err != nil {
+					log.WithValues(err, "while copying")
+					rec.Eventf(&secret, corev1.EventTypeWarning, "FailedCopying", err.Error())
+					return reconcile.Result{}, nil
+				}
+			}
+
+			copyKeystoreP12Key := secret.GetAnnotations()[secretSyncKeystoreP12AnnotKey]
+			if copyKeystoreP12Key != "" {
+				copyKey(secret, "keystore.p12", copyKeystoreP12Key)
+				if err != nil {
+					log.WithValues(err, "while copying")
+					rec.Eventf(&secret, corev1.EventTypeWarning, "FailedCopying", err.Error())
+					return reconcile.Result{}, nil
+				}
+			}
+
+			copyTruststoreP12Key := secret.GetAnnotations()[secretSyncTruststoreP12AnnotKey]
+			if copyTruststoreP12Key != "" {
+				copyKey(secret, "truststore.p12", copyTruststoreP12Key)
+				if err != nil {
+					log.WithValues(err, "while copying")
+					rec.Eventf(&secret, corev1.EventTypeWarning, "FailedCopying", err.Error())
+					return reconcile.Result{}, nil
+				}
+			}
+
 			if reflect.DeepEqual(secret.Data, secretBefore.Data) {
 				return reconcile.Result{}, nil
 			}
@@ -147,6 +195,18 @@ func main() {
 			if copyTLSKeyKey != "" {
 				rec.Eventf(&secret, corev1.EventTypeNormal, "CopiedKey", "Copied the contents of %q into key %q", "tls.key", copyTLSKeyKey)
 			}
+			if copyKeystoreJKSKey != "" {
+				rec.Eventf(&secret, corev1.EventTypeNormal, "CopiedKey", "Copied the contents of %q into key %q", "keystore.jks", copyKeystoreJKSKey)
+			}
+			if copyTruststoreJKSKey != "" {
+				rec.Eventf(&secret, corev1.EventTypeNormal, "CopiedKey", "Copied the contents of %q into key %q", "truststore.jks", copyTruststoreJKSKey)
+			}
+			if copyKeystoreP12Key != "" {
+				rec.Eventf(&secret, corev1.EventTypeNormal, "CopiedKey", "Copied the contents of %q into key %q", "keystore.p12", copyKeystoreP12Key)
+			}
+			if copyTruststoreP12Key != "" {
+				rec.Eventf(&secret, corev1.EventTypeNormal, "CopiedKey", "Copied the contents of %q into key %q", "truststore.p12", copyTruststoreP12Key)
+			}
 
 			return reconcile.Result{}, nil
 		}),
@@ -163,7 +223,11 @@ func main() {
 		if o.GetAnnotations()[secretAnnotKey] == "" &&
 			o.GetAnnotations()[secretSyncCACRTAnnotKey] == "" &&
 			o.GetAnnotations()[secretSyncTLSCrtAnnotKey] == "" &&
-			o.GetAnnotations()[secretSyncTLSKeyAnnotKey] == "" {
+			o.GetAnnotations()[secretSyncTLSKeyAnnotKey] == "" &&
+			o.GetAnnotations()[secretSyncKeystoreJKSAnnotKey] == "" &&
+			o.GetAnnotations()[secretSyncTruststoreJKSAnnotKey] == "" &&
+			o.GetAnnotations()[secretSyncKeystoreP12AnnotKey] == "" &&
+			o.GetAnnotations()[secretSyncTruststoreP12AnnotKey] == "" {
 			return nil
 		}
 


### PR DESCRIPTION
## Problem

As not all application are able to read pem formated certificate information cert-manager supports adding additonal keystores to the certificate secret.
There name is also fixed and I just encountered some vendor forcing users to use a specific key for keystore and truststore

## Solution

Similar to the other Keys I just added the keystores.

## Open

I didn't get it tested locally with some example, so testing is open.