### PR TITLE
Add vet and formatting checks to release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,6 +25,18 @@ jobs:
 
       - run: go test ./... -v
 
+      - name: Run go vet
+        run: go vet ./...
+
+      - name: Check formatting
+        run: |
+          diff=$(gofmt -d $(git ls-files '*.go'))
+          if [ -n "$diff" ]; then
+            echo "$diff"
+            echo 'Go files are not properly formatted'
+            exit 1
+          fi
+
       - name: Run GoReleaser (PR)
         uses: goreleaser/goreleaser-action@v5
         if: ${{ !startsWith(github.ref, 'refs/tags') }}


### PR DESCRIPTION
## Summary
- run `go vet` as part of the release workflow
- check `gofmt -d` and fail when formatting issues exist

## Testing
- `go test ./... -v`

------
https://chatgpt.com/codex/tasks/task_e_684eac684ca0832d87452117bd8dc4d7